### PR TITLE
Added support for worlds not loaded at server startup

### DIFF
--- a/src/main/java/org/projectdsm/dsmrealtime/DSMRealTime.java
+++ b/src/main/java/org/projectdsm/dsmrealtime/DSMRealTime.java
@@ -7,6 +7,7 @@ import com.google.gson.JsonObject;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.World;
+import org.bukkit.WorldCreator;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitScheduler;
@@ -249,6 +250,10 @@ public final class DSMRealTime extends JavaPlugin {
 
         /* Get Data from Config */
         world = getServer().getWorld(Objects.requireNonNull(getConfig().getString("World")));
+        if (world == null) { // World isn't loaded or doesn't exist
+            world = getServer().createWorld(new WorldCreator(getConfig().getString("World"))); // The createWorld() method will load a given world if it already exists
+            getLogger().info("World \"" + getConfig().getString("World") + "\" wasn't loaded or didn't exist. If nothing is happening in the world you expected, check your spelling in config.yml and delete any new worlds that were generated with the misspelled name.");
+        }
         timezone = getConfig().getString("Timezone");
         apiKey = getConfig().getString("APIKey");
         location = getConfig().getString("Location");


### PR DESCRIPTION
When trying to use the plugin on my server, it would always give me an error that the world didn't exist. The world in question was created using the Multiverse plugin, and was not loaded on server startup. The `getWorld()` method returns `null` for worlds that aren't loaded, which prevented this plugin from obtaining the `World` instance to set the time in weather. 

The `createWorld()` method, if given the name of an existing world, will load that world and return its corresponding `World` object. If the world in question does not exist, it will be created. There is no way around this that I can tell, however it would be possible to integrate Multiverse more to prevent this. 